### PR TITLE
feat: per-user logo resize opt-in via config token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,6 @@ ADDON_DESCRIPTION=Stream your IPTV channels in Stremio
 # Optional: URL of a logo/icon image to display in Stremio (leave commented out to disable)
 # ADDON_LOGO_URL=https://example.com/logo.png
 
-# Enable/disable logo proxy resizing to enforce Stremio 2:3 aspect ratio
-LOGO_RESIZE_ENABLED=true
-
 # Enable/disable Cache-Control headers on proxied logos
 LOGO_CACHE_ENABLED=true
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - 🔍 Category-based browsing + channel search
 - 🔐 Config tokens: base64-encoded (plain) or AES-256-GCM encrypted (with `CONFIG_SECRET`)
 - ⚡ Persistent SQLite cache with gzip compression, configurable TTL, and automatic garbage collection
-- 🖼️ Configurable Channel logo proxy with multi-source fallback, optional resizing and caching
+- 🖼️ Configurable Channel logo proxy with multi-source fallback, per-user resize opt-in, and optional caching
 - 🛡️ SSRF-protected server-side CORS bypass proxy for pre-flight validation
 - 🛑 Hybrid Rate Limiting to prevent API abuse (Global IP & Token-based)
 
@@ -89,7 +89,6 @@ services:
 | `ADDON_NAME` | `IPTV Stremio Addon` | Addon name shown in Stremio |
 | `ADDON_DESCRIPTION` | `Stream your IPTV channels in Stremio` | Addon description shown in Stremio |
 | `ADDON_LOGO_URL` | *(unset)* | URL for the addon logo in Stremio |
-| `LOGO_RESIZE_ENABLED` | `true` | Wrap logos in wsrv.nl proxy to enforce 2:3 aspect ratio |
 | `LOGO_CACHE_ENABLED` | `true` | Apply Cache-Control headers to logo proxy responses |
 | `IP_RATE_LIMIT_ENABLED` | `true` | Enable global IP-based rate limiting |
 | `IP_RATE_LIMIT_WINDOW_MS` | `300000` (5m) | Window in ms for IP rate limit |

--- a/public/html/xtream-config.html
+++ b/public/html/xtream-config.html
@@ -80,6 +80,11 @@
                                 <input type="number" step="0.25" id="epgOffsetHours" name="epgOffsetHours"
                                     placeholder="0">
                             </div>
+
+                            <div class="form-group checkbox-line" style="margin-top: 15px;">
+                                <input type="checkbox" id="resizeLogo" name="resizeLogo">
+                                <label class="checkbox-label" for="resizeLogo">Resize logos (may slow down loading)</label>
+                            </div>
                         </fieldset>
 
 

--- a/public/js/xtream-config.js
+++ b/public/js/xtream-config.js
@@ -17,6 +17,7 @@
     const epgOffsetInput = document.getElementById('epgOffsetHours');
     const customEpgGroup = document.getElementById('customEpgGroup');
     const customEpgUrlInp = document.getElementById('customEpgUrl');
+    const resizeLogoChk = document.getElementById('resizeLogo');
 
     const epgModeRadios = () => [...document.querySelectorAll('input[name="epgMode"]')];
 
@@ -168,6 +169,7 @@
         const epgMode = enableEpgInitial ? selectedEpgMode() : 'disabled';
         const customEpg = (epgMode === 'custom') ? customEpgUrlInp.value.trim() : '';
         const epgOffset = epgOffsetInput.value ? parseFloat(epgOffsetInput.value) : 0;
+        const resizeLogo = resizeLogoChk ? resizeLogoChk.checked : false;
 
         if (!validateUrl(baseUrl)) {
             alert('Invalid Xtream base URL');
@@ -271,7 +273,8 @@
                 xtreamUrl: baseUrl,
                 xtreamUsername: username,
                 xtreamPassword: password,
-                enableEpg: enableEpgFinal
+                enableEpg: enableEpgFinal,
+                resizeLogo: resizeLogo
             };
 
             if (enableEpgFinal && epgMode === 'custom' && customEpgUrlInp.value.trim()) {

--- a/src/addon/M3UEPGAddon.js
+++ b/src/addon/M3UEPGAddon.js
@@ -26,7 +26,8 @@ function createCacheKey(config) {
         enableEpg: !!config.enableEpg,
         xtreamUrl: config.xtreamUrl,
         xtreamUsername: config.xtreamUsername,
-        epgOffsetHours: config.epgOffsetHours
+        epgOffsetHours: config.epgOffsetHours,
+        resizeLogo: !!config.resizeLogo
     };
     return crypto.createHash('md5').update(stableStringify(minimal)).digest('hex');
 }
@@ -153,7 +154,7 @@ class M3UEPGAddon {
             }
         }
 
-        if (env.LOGO_RESIZE_ENABLED && finalUrl.startsWith('http') && !finalUrl.includes('wsrv.nl')) {
+        if (this.config.resizeLogo && finalUrl.startsWith('http') && !finalUrl.includes('wsrv.nl')) {
             return `https://wsrv.nl/?url=${encodeURIComponent(finalUrl)}&w=250&h=375&fit=contain&bg=black`;
         }
         return finalUrl;

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -13,7 +13,6 @@ module.exports = {
     ADDON_NAME: process.env.ADDON_NAME || 'IPTV Stremio Addon',
     ADDON_DESCRIPTION: process.env.ADDON_DESCRIPTION || 'Stream your IPTV channels in Stremio',
     ADDON_LOGO_URL: process.env.ADDON_LOGO_URL || 'https://i.imgur.com/vN5tLuv.jpeg',
-    LOGO_RESIZE_ENABLED: (process.env.LOGO_RESIZE_ENABLED || 'true').toLowerCase() !== 'false',
     LOGO_CACHE_ENABLED: (process.env.LOGO_CACHE_ENABLED || 'true').toLowerCase() !== 'false',
     CONFIG_SECRET: process.env.CONFIG_SECRET || null,
     IP_RATE_LIMIT_ENABLED: (process.env.IP_RATE_LIMIT_ENABLED || 'true').toLowerCase() !== 'false',

--- a/src/routes/logo.js
+++ b/src/routes/logo.js
@@ -43,7 +43,7 @@ router.get('/:token/logo/:tvgId.png', async (req, res) => {
                 if (head.ok) {
                     const len = parseInt(head.headers.get('content-length'), 10);
                     if (isNaN(len) || len > 50) {
-                        if (env.LOGO_RESIZE_ENABLED === true) {
+                        if (req.userConfig && req.userConfig.resizeLogo === true) {
                             if (head.body) {
                                 try { await head.body.cancel(); } catch (e) { /* ignore */ }
                             }

--- a/src/routes/stremio.js
+++ b/src/routes/stremio.js
@@ -61,6 +61,7 @@ router.use('/:token', async (req, res, next) => {
 
     req.addonInterface = iface;
     req.configToken = token;
+    req.userConfig = config;
     next();
 });
 


### PR DESCRIPTION
## Summary

Converts the logo resize feature from a global server-side environment variable (`LOGO_RESIZE_ENABLED`) into a per-user preference stored in the config token. Users can now opt-in to Stremio-formatted logos (2:3 aspect ratio via `wsrv.nl`) directly on the setup page, without requiring any server configuration.

Old tokens without `resizeLogo` will default to `false` (no resize) — **no breaking changes for existing users**.

---

## Changes

### Frontend

- **`public/html/xtream-config.html`**: Added a _"Resize logos (may slow down loading)"_ checkbox in the EPG Options fieldset
- **`public/js/xtream-config.js`**: Captures the checkbox state and includes `resizeLogo: bool` in the config payload before token encryption

### Backend

- **`src/routes/stremio.js`**: Exposes the decoded config as `req.userConfig` on the request object, so downstream routes can access per-user settings without re-decoding the token
- **`src/routes/logo.js`**: Replaced `env.LOGO_RESIZE_ENABLED` check with `req.userConfig?.resizeLogo === true` — old tokens safely fall back to `false`
- **`src/addon/M3UEPGAddon.js`**:
  - Replaced `env.LOGO_RESIZE_ENABLED` with `this.config.resizeLogo` in `deriveFallbackLogoUrl` (catalog poster URLs)
  - Added `resizeLogo` to `createCacheKey` so tokens with different resize preferences get independent addon instances and don't share state
- **`src/config/env.js`**: Removed `LOGO_RESIZE_ENABLED`

### Documentation

- **`.env.example`**: Removed `LOGO_RESIZE_ENABLED` entry
- **`README.md`**: Removed `LOGO_RESIZE_ENABLED` from env table; updated feature bullet to reflect per-user opt-in

---

## Migration Notes

- Existing users with old tokens are unaffected — `resizeLogo` defaults to `false`, giving them an immediate performance boost (no wsrv.nl proxy on logo loads)
- Users who want logo resizing must regenerate their setup URL with the checkbox enabled
