### PR TITLE
feat: implement multi-select filters for IPTV-org and bump version to v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - 📺 **Dynamic Providers:** Live TV channels via **Xtream Codes JSON API** or the **IPTV-org Public Repository**
 - ⚙️ **Unified Configuration:** Responsive, tabbed setup interface for both providers
 - 📡 **EPG Support (Xtream):** panel XMLTV or custom XMLTV URL, pruned and optimized for low memory and CPU footprint
-- 🔍 **Filtering & Search:** Category-based browsing and search, plus Country filtering (IPTV-org)
+- 🔍 **Filtering & Search:** Category-based browsing and search, plus multi-select Country and Category filtering for IPTV-org (with intra-category OR, inter-category AND logic)
 - 🔐 Config tokens: base64-encoded (plain) or AES-256-GCM encrypted (with `CONFIG_SECRET`)
 - ⚡ Persistent SQLite cache with gzip compression, configurable TTL, and automatic garbage collection
 - 🖼️ Configurable Channel logo proxy with multi-source fallback, per-user resize opt-in, and optional caching

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stremio-iptv-addon",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Stream your IPTV channels in Stremio",
   "main": "server.js",
   "scripts": {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -173,6 +173,25 @@ legend {
     padding-bottom: 0.5rem;
 }
 
+.info-banner {
+    background: rgba(16, 185, 129, 0.08);
+    border: 1px solid rgba(16, 185, 129, 0.25);
+    border-radius: var(--radius-sm);
+    padding: 0.85rem 1rem;
+    font-size: 0.85rem;
+    color: #6ee7b7;
+    display: flex;
+    gap: 0.65rem;
+    align-items: flex-start;
+    margin-bottom: 1.25rem;
+    line-height: 1.5;
+}
+
+.info-banner svg {
+    flex-shrink: 0;
+    margin-top: 1px;
+}
+
 .form-group {
     margin-bottom: 1.25rem;
     display: flex;
@@ -643,4 +662,49 @@ input[type="radio"] {
 .searchable-select-dropdown li.ss-no-results:hover {
     background: transparent;
     color: var(--text-faint);
+}
+
+/* ── Tags (Multi-Select Pills) ─────────────────────────────────────────────── */
+.selected-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    padding-bottom: 0;
+    position: absolute;
+    top: 1px;
+    left: 1px;
+    right: 1px;
+    background: transparent;
+    pointer-events: none;
+}
+
+.searchable-select:has(.selected-tags:not(:empty)) .searchable-select-input {
+    padding-top: 2.75rem;
+}
+
+.selected-tags .tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    background: var(--accent-gradient);
+    color: #fff;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    pointer-events: auto;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.selected-tags .tag .remove-tag {
+    cursor: pointer;
+    font-weight: 700;
+    padding: 0 0.15rem;
+    opacity: 0.7;
+    transition: opacity 0.2s;
+}
+
+.selected-tags .tag .remove-tag:hover {
+    opacity: 1;
 }

--- a/public/html/xtream-config.html
+++ b/public/html/xtream-config.html
@@ -46,9 +46,23 @@
                             <fieldset>
                                 <legend>Channel Filter</legend>
 
+                                <div class="info-banner">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                        <circle cx="12" cy="12" r="10"></circle>
+                                        <path d="M12 16v-4M12 8h.01"></path>
+                                    </svg>
+                                    <span>
+                                        Uses the free <strong>iptv-org</strong> community database (~50k channels from
+                                        200+ countries).
+                                        No credentials needed. Use the filters below to narrow down the list.
+                                    </span>
+                                </div>
+
                                 <div class="form-group">
                                     <label for="iptvOrgCountryInput">Country</label>
                                     <div class="searchable-select" id="iptvOrgCountrySelect">
+                                        <div class="selected-tags"></div>
                                         <input type="text" id="iptvOrgCountryInput" class="searchable-select-input"
                                             placeholder="All Countries (search to filter…)" autocomplete="off"
                                             role="combobox" aria-expanded="false" aria-autocomplete="list"
@@ -63,6 +77,7 @@
                                 <div class="form-group">
                                     <label for="iptvOrgCategoryInput">Category</label>
                                     <div class="searchable-select" id="iptvOrgCategorySelect">
+                                        <div class="selected-tags"></div>
                                         <input type="text" id="iptvOrgCategoryInput" class="searchable-select-input"
                                             placeholder="All Categories (search to filter…)" autocomplete="off"
                                             role="combobox" aria-expanded="false" aria-autocomplete="list"

--- a/public/js/iptv-org-config.js
+++ b/public/js/iptv-org-config.js
@@ -35,18 +35,56 @@
         const input = document.getElementById(inputId);
         const hidden = document.getElementById(hiddenId);
         const list = document.getElementById(listId);
+        const container = input ? input.closest('.searchable-select') : null;
+        const tagsContainer = container ? container.querySelector('.selected-tags') : null;
 
-        if (!input || !hidden || !list) return;
+        if (!input || !hidden || !list || !tagsContainer) return;
 
+        let selectedItems = [];
         input.placeholder = placeholder || 'Search…';
+
+        function updateHidden() {
+            hidden.value = selectedItems.map(i => i.value).join(',');
+            input.placeholder = selectedItems.length > 0 ? '' : (placeholder || 'Search…');
+        }
+
+        function renderTags() {
+            tagsContainer.innerHTML = '';
+            selectedItems.forEach(it => {
+                const span = document.createElement('span');
+                span.className = 'tag';
+                // Remove bracketed info for smaller pills if length is long
+                let shortLabel = it.label.split(' (')[0].trim();
+                span.textContent = shortLabel;
+
+                const removeBtn = document.createElement('span');
+                removeBtn.className = 'remove-tag';
+                removeBtn.textContent = '×';
+                removeBtn.setAttribute('data-value', it.value);
+
+                removeBtn.addEventListener('mousedown', (e) => {
+                    e.preventDefault(); // prevent losing focus on input right before click triggers
+                    e.stopPropagation();
+                    selectedItems = selectedItems.filter(s => s.value !== it.value);
+                    renderTags();
+                    updateHidden();
+                    renderItems(input.value);
+                });
+
+                span.appendChild(removeBtn);
+                tagsContainer.appendChild(span);
+            });
+        }
 
         function renderItems(filter) {
             const q = (filter || '').toLowerCase().trim();
             list.innerHTML = '';
 
+            const availableItems = items.filter(it => it.value !== '' && !selectedItems.some(s => s.value === it.value));
+
             const filtered = q
-                ? items.filter(it => it.label.toLowerCase().includes(q))
-                : items;
+                ? availableItems.filter(it => it.label.toLowerCase().includes(q))
+                : availableItems;
 
             if (filtered.length === 0) {
                 const li = document.createElement('li');
@@ -71,9 +109,15 @@
         }
 
         function selectItem(it) {
-            input.value = it.value ? it.label : '';
-            hidden.value = it.value ?? '';
+            if (it.value === '') return;
+            if (!selectedItems.some(s => s.value === it.value)) {
+                selectedItems.push(it);
+            }
+            input.value = '';
+            renderTags();
+            updateHidden();
             closeDropdown();
+            input.focus();
         }
 
         function openDropdown() {
@@ -89,7 +133,6 @@
 
         input.addEventListener('focus', () => openDropdown());
         input.addEventListener('input', () => {
-            hidden.value = '';
             renderItems(input.value);
             list.classList.remove('hidden');
         });
@@ -122,16 +165,30 @@
                 }
             } else if (e.key === 'Escape') {
                 closeDropdown();
+            } else if (e.key === 'Backspace' && input.value === '' && selectedItems.length > 0) {
+                // remove last pill if pressing backspace on empty input
+                selectedItems.pop();
+                renderTags();
+                updateHidden();
+                renderItems(input.value);
             }
         });
 
+        function setSelection(itemsArr) {
+            selectedItems = itemsArr.filter(i => i && i.value);
+            renderTags();
+            updateHidden();
+        }
+
         renderItems('');
 
-        return { selectItem, renderItems };
+        return { selectItem, renderItems, setSelection };
     }
 
     let countriesLoaded = [];
     let categoriesLoaded = [];
+    let countrySelectObj;
+    let categorySelectObj;
 
     async function loadIptvOrgData() {
         try {
@@ -140,34 +197,34 @@
                 fetch(`${IPTV_ORG_BASE}/categories.json`).then(r => r.json()),
             ]);
 
-            const countryItems = [{ label: 'All Countries', value: '' }];
+            const countryItems = [];
             const sorted = [...countriesRaw].sort((a, b) => a.name.localeCompare(b.name));
             sorted.forEach(c => {
                 countryItems.push({ label: `${c.name} (${c.code.toUpperCase()})`, value: c.code.toUpperCase() });
             });
             countriesLoaded = countryItems;
 
-            const categoryItems = [{ label: 'All Categories', value: '' }];
+            const categoryItems = [];
             const sortedCats = [...categoriesRaw].sort((a, b) => a.name.localeCompare(b.name));
             sortedCats.forEach(c => {
                 categoryItems.push({ label: capitalize(c.name), value: c.id });
             });
             categoriesLoaded = categoryItems;
 
-            buildSearchableSelect({
+            countrySelectObj = buildSearchableSelect({
                 inputId: 'iptvOrgCountryInput',
                 hiddenId: 'iptvOrgCountry',
                 listId: 'iptvOrgCountryList',
                 items: countriesLoaded,
-                placeholder: 'All Countries (search to filter…)',
+                placeholder: 'Search to add country…',
             });
 
-            buildSearchableSelect({
+            categorySelectObj = buildSearchableSelect({
                 inputId: 'iptvOrgCategoryInput',
                 hiddenId: 'iptvOrgCategory',
                 listId: 'iptvOrgCategoryList',
                 items: categoriesLoaded,
-                placeholder: 'All Categories (search to filter…)',
+                placeholder: 'Search to add category…',
             });
 
             tryPrefillIptvOrg();
@@ -186,20 +243,16 @@
 
         activateTab('panel-iptv-org');
 
-        if (decoded.iptvOrgCountry) {
-            const match = countriesLoaded.find(c => c.value === decoded.iptvOrgCountry.toUpperCase());
-            if (match) {
-                document.getElementById('iptvOrgCountryInput').value = match.label;
-                document.getElementById('iptvOrgCountry').value = match.value;
-            }
+        if (decoded.iptvOrgCountry && countrySelectObj) {
+            const reqCodes = decoded.iptvOrgCountry.split(',').map(c => c.trim().toUpperCase());
+            const matches = reqCodes.map(req => countriesLoaded.find(c => c.value === req)).filter(Boolean);
+            countrySelectObj.setSelection(matches);
         }
 
-        if (decoded.iptvOrgCategory) {
-            const match = categoriesLoaded.find(c => c.value === decoded.iptvOrgCategory.toLowerCase());
-            if (match) {
-                document.getElementById('iptvOrgCategoryInput').value = match.label;
-                document.getElementById('iptvOrgCategory').value = match.value;
-            }
+        if (decoded.iptvOrgCategory && categorySelectObj) {
+            const reqCats = decoded.iptvOrgCategory.split(',').map(c => c.trim().toLowerCase());
+            const matches = reqCats.map(req => categoriesLoaded.find(c => c.value === req)).filter(Boolean);
+            categorySelectObj.setSelection(matches);
         }
     }
 

--- a/src/addon/builder.js
+++ b/src/addon/builder.js
@@ -13,7 +13,7 @@ async function createAddon(config) {
     const cacheKey = createCacheKey(config);
     const debugFlag = !!env.DEBUG;
     if (debugFlag) {
-        console.log('[DEBUG] createAddon start', { cacheKey, provider: 'xtream' });
+        console.log('[DEBUG] createAddon start', { cacheKey, provider: config.provider || 'xtream' });
     } else {
         console.log(`[ADDON] Cache ${CACHE_ENABLED ? 'ENABLED' : 'DISABLED'} for config ${cacheKey}`);
     }
@@ -40,7 +40,8 @@ async function createAddon(config) {
             const start = Date.now();
             try {
                 addonInstance.updateData().catch(() => { });
-                let items = args.type === 'tv' && args.id === 'iptv_channels' ? addonInstance.channels : [];
+                const catalogIds = ['iptv_channels', 'iptv_org'];
+                let items = args.type === 'tv' && catalogIds.includes(args.id) ? addonInstance.channels : [];
                 const extra = args.extra || {};
                 if (extra.genre && extra.genre !== 'All Channels') {
                     items = items.filter(i =>
@@ -98,7 +99,9 @@ async function createAddon(config) {
             }
         });
 
-        return builder.getInterface();
+        const iface = builder.getInterface();
+        iface.addonInstance = addonInstance;
+        return iface;
     })();
 
     if (CACHE_ENABLED) buildPromiseCache.set(cacheKey, buildPromise);

--- a/src/addon/manifest.js
+++ b/src/addon/manifest.js
@@ -3,7 +3,7 @@ const env = require('../config/env');
 function createManifest() {
     return {
         id: 'org.stremio.iptv-addon',
-        version: '1.0.0',
+        version: '1.2.0',
         name: env.ADDON_NAME,
         description: env.ADDON_DESCRIPTION,
         resources: ['catalog', 'stream', 'meta'],

--- a/src/providers/iptvOrgProvider.js
+++ b/src/providers/iptvOrgProvider.js
@@ -11,8 +11,8 @@ async function fetchJson(url) {
 async function fetchData(addonInstance) {
     const { config } = addonInstance;
 
-    const filterCountry = config.iptvOrgCountry ? config.iptvOrgCountry.toUpperCase() : null;
-    const filterCategory = config.iptvOrgCategory ? config.iptvOrgCategory.toLowerCase() : null;
+    const filterCountries = config.iptvOrgCountry ? config.iptvOrgCountry.split(',').map(c => c.trim().toUpperCase()).filter(c => c) : [];
+    const filterCategories = config.iptvOrgCategory ? config.iptvOrgCategory.split(',').map(c => c.trim().toLowerCase()).filter(c => c) : [];
 
     addonInstance.channels = [];
     addonInstance.epgData = {};
@@ -43,13 +43,14 @@ async function fetchData(addonInstance) {
         const urls = streamMap[ch.id];
         if (!urls || urls.length === 0) continue;
 
-        if (filterCountry && ch.country !== filterCountry) continue;
+        if (filterCountries.length > 0 && !filterCountries.includes(ch.country)) continue;
 
-        if (filterCategory) {
+        if (filterCategories.length > 0) {
             const cats = Array.isArray(ch.categories)
                 ? ch.categories.map(c => c.toLowerCase())
                 : [];
-            if (!cats.includes(filterCategory)) continue;
+            const overlap = cats.some(c => filterCategories.includes(c));
+            if (!overlap) continue;
         }
 
         const category = ch.categories?.[0] || 'Live TV';

--- a/src/routes/stremio.js
+++ b/src/routes/stremio.js
@@ -61,6 +61,11 @@ router.use('/:token', async (req, res, next) => {
     req.addonInterface = iface;
     req.configToken = token;
     req.userConfig = config;
+
+    if (iface.addonInstance) {
+        iface.addonInstance.buildGenresInManifest();
+    }
+
     next();
 });
 
@@ -69,6 +74,11 @@ router.use(require('./logo'));
 router.get('/:token/manifest.json', tokenLimiter, (req, res) => {
     const iface = req.addonInterface;
     if (!iface) return res.status(500).json({ error: 'Interface not ready' });
+
+    // Ensure manifest genres are fresh before serving
+    if (iface.addonInstance) {
+        iface.addonInstance.buildGenresInManifest();
+    }
     const manifest = JSON.parse(JSON.stringify(iface.manifest));
     if (manifest.behaviorHints) {
         delete manifest.behaviorHints.configurationRequired;


### PR DESCRIPTION
## Description
This PR implements a major enhancement to the IPTV-org provider by allowing users to select multiple countries and categories simultaneously.

### Key Changes:
- **Multi-Select UI**: Replaced the standard dropdowns with a custom pill/tag-based multi-selection interface in the configuration page.
- **Improved Filtering Logic**: Updated the backend to process comma-separated values. It now applies **OR** logic within a filter type (e.g., US OR BR) and **AND** logic between filter types (e.g., US AND Sports).
- **Genre Synchronization**: Implemented a request-time manifest genre rebuild to ensure Stremio always displays up-to-date category filters even if the initial load was empty.
- **Bug Fixes**:
  - Fixed "PUBLIC CHANNELS" banner layout alignment.
  - Corrected hardcoded provider names in debug logs.
  - Added `iptv_org` as a catalog ID alias for improved robustness.
- **Version Bump**: Updated project version to `v1.2.0`.

## Testing
- Verified pill selection and removal in the configuration frontend.
- Tested generated manifests with multiple countries and categories using local dev server.
- Confirmed that Stremio correctly displays the category filters in the genre dropdown.
