### PR TITLE
fix: always proxy M3U logos through wsrv.nl

### DIFF
--- a/src/addon/M3UEPGAddon.js
+++ b/src/addon/M3UEPGAddon.js
@@ -83,7 +83,7 @@ class M3UEPGAddon {
         if (Math.abs(this.config.epgOffsetHours) > 48)
             this.config.epgOffsetHours = 0;
 
-        if (this.providerName === 'iptv-org') {
+        if (this.providerName === 'iptv-org' || this.providerName === 'm3u') {
             this.config.reformatLogos = true;
         }
 
@@ -213,7 +213,7 @@ class M3UEPGAddon {
 
     deriveFallbackLogoUrl(item) {
         let finalUrl;
-        const logoAttr = item.attributes?.['tvg-logo'];
+        const logoAttr = item.attributes?.['tvg-logo'] || item.logo;
         if (logoAttr && logoAttr.trim()) {
             finalUrl = logoAttr;
         } else {


### PR DESCRIPTION
## Summary
- Force `reformatLogos=true` for the M3U provider (same behavior as iptv-org) so all logo URLs are proxied through wsrv.nl
- Add `item.logo` as fallback in `deriveFallbackLogoUrl` in case `attributes['tvg-logo']` is absent

## Why
M3U playlist logo URLs are often HTTP, which Stremio blocks due to mixed-content policy when the addon is served over HTTPS. Additionally, IPTV CDNs frequently lack CORS headers, preventing Stremio from loading the images. Routing all logos through wsrv.nl ensures HTTPS delivery with proper CORS headers.

## Test plan
- [ ] Install M3U addon with a playlist that has `tvg-logo` attributes
- [ ] Confirm channel logos now appear in the Stremio catalog (no more TV placeholder icons)
- [ ] Confirm iptv-org and Xtream provider logos are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)