### PR TITLE
feat(m3u): global user-agent config with preset chips

### DIFF
--- a/packages/backend/src/addon/M3UEPGAddon.ts
+++ b/packages/backend/src/addon/M3UEPGAddon.ts
@@ -38,6 +38,7 @@ export interface AddonConfig {
     iptvOrgCategory?: string;
     instanceId?: string;
     catalogName?: string;
+    globalUserAgent?: string;
 }
 
 function stableStringify(obj: any) {
@@ -61,6 +62,7 @@ export function createCacheKey(config: AddonConfig) {
             epgUrl: config.epgUrl || null,
             epgOffsetHours: config.epgOffsetHours,
             reformatLogos: !!config.reformatLogos,
+            globalUserAgent: config.globalUserAgent || null,
         };
     } else {
         minimal = {

--- a/packages/backend/src/providers/m3uProvider.ts
+++ b/packages/backend/src/providers/m3uProvider.ts
@@ -80,7 +80,7 @@ export async function fetchData(addonInstance: any) {
             logo:     ch.logo || '',
             category: ch.group,
             epg_channel_id: ch.tvgId || ch.tvgName || '',
-            userAgent: ch.userAgent || '',
+            userAgent: ch.userAgent || config.globalUserAgent || '',
             referrer:  ch.referrer || '',
             attributes: {
                 'tvg-id':      ch.tvgId,

--- a/packages/frontend/src/assets/styles.css
+++ b/packages/frontend/src/assets/styles.css
@@ -661,6 +661,12 @@ input[type="radio"]:checked::after {
 .chip-label { font-size: 0.875rem; font-weight: 500; }
 .chip-note  { font-size: 0.75rem; color: var(--text-2); }
 
+.playlist-chip.active {
+    background: var(--accent-dim);
+    border-color: var(--accent);
+    color: var(--accent-2);
+}
+
 /* ═══════════════════════════════════════════════════════════
    About Card (sidebar)
 ═══════════════════════════════════════════════════════════ */

--- a/packages/frontend/src/components/M3uConfig.vue
+++ b/packages/frontend/src/components/M3uConfig.vue
@@ -89,6 +89,39 @@
     </fieldset>
 
     <fieldset>
+      <legend>Advanced</legend>
+      <div class="form-group">
+        <label class="group-label">Global User-Agent
+          <span class="hint"> — leave blank unless your provider requires a specific player</span>
+        </label>
+        <div class="playlist-chips">
+          <button
+            v-for="p in USER_AGENT_PRESETS"
+            :key="p.value"
+            type="button"
+            class="playlist-chip"
+            :class="{ active: form.userAgentPreset === p.value }"
+            @click="selectPreset(p.value)"
+          >
+            <span class="chip-label">{{ p.label }}</span>
+          </button>
+          <button
+            type="button"
+            class="playlist-chip"
+            :class="{ active: form.userAgentPreset === 'custom' }"
+            @click="selectPreset('custom')"
+          >
+            <span class="chip-label">Custom…</span>
+          </button>
+        </div>
+        <input v-if="form.userAgentPreset === 'custom'" type="text" id="m3uGlobalUserAgent"
+          v-model="form.globalUserAgent" placeholder="e.g. MyPlayer/1.0"
+          style="margin-top: 0.5rem">
+        <small class="hint">Channels with their own User-Agent in the playlist take priority over this setting.</small>
+      </div>
+    </fieldset>
+
+    <fieldset>
       <legend>Display</legend>
       <div class="form-group">
         <label for="m3uCatalogName">Catalog Name</label>
@@ -119,6 +152,14 @@ import type { M3uConfig } from '../types/config'
 const oc = inject<any>('overlayControl')!
 const { playlists } = usePublicPlaylists()
 
+const USER_AGENT_PRESETS = [
+  { label: 'TiviMate',         value: 'TiviMate/4.7.0 (Android)' },
+  { label: 'IPTV Smarters Pro', value: 'IPTV Smarters Pro' },
+  { label: 'GSE Smart IPTV',   value: 'GSE/7.6 CFNetwork/1410.1 Darwin/22.6.0' },
+  { label: 'VLC',              value: 'VLC/3.0.18 LibVLC/3.0.18' },
+  { label: 'Kodi',             value: 'Kodi/21.0 (X11; Linux x86_64) App_Bitness/64 Version/21.0' },
+]
+
 const form = reactive({
   m3uUrl: '',
   enableEpg: false,
@@ -127,7 +168,20 @@ const form = reactive({
   epgOffsetHours: 0,
   reformatLogos: false,
   catalogName: '',
+  userAgentPreset: '',
+  globalUserAgent: '',
 })
+
+function selectPreset(value: string) {
+  if (form.userAgentPreset === value) {
+    // toggle off
+    form.userAgentPreset = ''
+    form.globalUserAgent = ''
+    return
+  }
+  form.userAgentPreset = value
+  form.globalUserAgent = value !== 'custom' ? value : ''
+}
 
 onMounted(() => {
   const { decodedConfig } = useDecodedToken()
@@ -142,6 +196,12 @@ onMounted(() => {
   form.epgOffsetHours = d.epgOffsetHours ?? 0
   form.reformatLogos = !!d.reformatLogos
   form.catalogName = (decodedConfig as any).catalogName || ''
+  const savedUa = d.globalUserAgent || ''
+  if (savedUa) {
+    const match = USER_AGENT_PRESETS.find(p => p.value === savedUa)
+    form.userAgentPreset = match ? match.value : 'custom'
+    form.globalUserAgent = savedUa
+  }
 })
 
 async function handleInstall() {
@@ -164,6 +224,7 @@ async function handleInstall() {
     ...(enableEpg && epgOffsetHours !== 0 ? { epgOffsetHours } : {}),
     ...(enableEpg && customEpgUrl ? { epgUrl: customEpgUrl } : {}),
     ...(form.catalogName.trim() ? { catalogName: form.catalogName.trim() } : {}),
+    ...(form.globalUserAgent.trim() ? { globalUserAgent: form.globalUserAgent.trim() } : {}),
   }
 
   oc.showOverlay(false)

--- a/packages/frontend/src/types/config.ts
+++ b/packages/frontend/src/types/config.ts
@@ -33,6 +33,7 @@ export interface M3uConfig {
   epgUrl?: string;
   epgOffsetHours?: number;
   reformatLogos: boolean;
+  globalUserAgent?: string;
 }
 
 export type AddonConfig = (XtreamConfig | IptvOrgConfig | M3uConfig) & { catalogName?: string };


### PR DESCRIPTION
Closes #24

## Summary

- Adds a **Global User-Agent** field to the M3U config page, allowing users to set a fallback `User-Agent` header sent with every stream request
- Per-channel user-agent declared in the playlist still takes priority over the global setting
- Exposes 5 common IPTV player presets as toggleable chips (TiviMate, IPTV Smarters Pro, GSE Smart IPTV, VLC, Kodi) with a "Custom…" option for free-text input
- Global user-agent is included in the cache key, so different UA configs produce independent addon instances
- No behavior change for existing users who don't set this field

## Changes

- `AddonConfig` — new optional `globalUserAgent` field
- `createCacheKey` — includes `globalUserAgent` in the m3u cache key
- `m3uProvider` — applies `config.globalUserAgent` as fallback when the channel has no per-channel user-agent
- `M3uConfig` type — new optional `globalUserAgent` field
- `M3uConfig.vue` — new Advanced fieldset with chip-based preset selector + custom text input
- `styles.css` — `.playlist-chip.active` state for selected chip highlight